### PR TITLE
Add explicit no-op auth handlers

### DIFF
--- a/flask_jsonapiview/__init__.py
+++ b/flask_jsonapiview/__init__.py
@@ -1,8 +1,10 @@
 # flake8: noqa
 
 from .api import Api
-from .authentication import AuthenticationBase
-from .authorization import AuthorizationBase, HasAnyCredentialsAuthorization
+from .authentication import AuthenticationBase, NoOpAuthentication
+from .authorization import (
+    AuthorizationBase, HasAnyCredentialsAuthorization, NoOpAuthorization
+)
 from .decorators import get_item_or_404
 from .fields import *
 from .pagination import IdCursorPagination

--- a/flask_jsonapiview/authentication.py
+++ b/flask_jsonapiview/authentication.py
@@ -20,3 +20,11 @@ class AuthenticationBase(object):
 
     def get_request_credentials(self):
         raise NotImplementedError()
+
+
+# -----------------------------------------------------------------------------
+
+
+class NoOpAuthentication(AuthenticationBase):
+    def authenticate_request(self):
+        pass

--- a/flask_jsonapiview/authorization.py
+++ b/flask_jsonapiview/authorization.py
@@ -33,11 +33,9 @@ class AuthorizationBase(object):
 # -----------------------------------------------------------------------------
 
 
-class HasAnyCredentialsAuthorization(AuthorizationBase):
+class NoOpAuthorization(AuthorizationBase):
     def authorize_request(self):
-        if self.get_request_credentials() is None:
-            logger.warning("no request credentials")
-            flask.abort(401)
+        pass
 
     def filter_query(self, query, view):
         return query
@@ -50,3 +48,10 @@ class HasAnyCredentialsAuthorization(AuthorizationBase):
 
     def authorize_delete_item(self, item):
         pass
+
+
+class HasAnyCredentialsAuthorization(NoOpAuthorization):
+    def authorize_request(self):
+        if self.get_request_credentials() is None:
+            logger.warning("no request credentials")
+            flask.abort(401)


### PR DESCRIPTION
This allows derived views to call into the authorization handler without
checking for their existence